### PR TITLE
Add a naive results page with a grid of images.

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -8,6 +8,7 @@ import { AppRoutes } from "../consts/routes";
 import { ReportDogPage } from "../pages/dogs/ReportDogPage";
 import { SearchDogPage } from "../pages/dogs/SearchDogPage";
 import { createStyleHook } from "../hooks/styleHooks";
+import { ResultsDogPage } from "../pages/dogs/ResultsDogPage";
 
 const useAppStyles = createStyleHook(() => {
   return {
@@ -34,6 +35,7 @@ export const App = () => {
             <Route path={AppRoutes.root} element={<HomePage />} />
             <Route path={AppRoutes.dogs.report} element={<ReportDogPage />} />
             <Route path={AppRoutes.dogs.search} element={<SearchDogPage />} />
+            <Route path={AppRoutes.dogs.results} element={<ResultsDogPage />} />
           </Routes>
         </BrowserRouter>
       </Box>

--- a/src/components/resultsComponents/DogCard.tsx
+++ b/src/components/resultsComponents/DogCard.tsx
@@ -1,0 +1,22 @@
+import { Card, CardActions, CardMedia, Link } from "@mui/material";
+import { AppTexts } from "../../consts/texts";
+import { Dog } from "./ResultsGrid";
+
+export const DogCard = ({ dog }: { dog: Dog }) => {
+  return (
+    <Card>
+      <CardMedia
+        image={dog.image}
+        component="img"
+        style={{ objectFit: "contain" }}
+        title="Dog Image"
+        sx={{ height: 400 }}
+      />
+      <CardActions>
+        <Link underline="none" href={`tel:${dog.phone}`}>
+          {AppTexts.resultsPage.call}
+        </Link>
+      </CardActions>
+    </Card>
+  );
+};

--- a/src/components/resultsComponents/ResultsGrid.tsx
+++ b/src/components/resultsComponents/ResultsGrid.tsx
@@ -1,0 +1,22 @@
+import { Grid } from "@mui/material";
+import { DogCard } from "./DogCard";
+
+export type Dog = {
+  id: string;
+  phone: string;
+  image: string;
+};
+
+export const ResultsGrid = ({ results }: { results: Dog[] }) => {
+  return (
+    <Grid container spacing={2}>
+      {results.map((dog) => {
+        return (
+          <Grid item xs={12} md={6} lg={4} key={dog.id}>
+            <DogCard dog={dog} />
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+};

--- a/src/consts/routes.ts
+++ b/src/consts/routes.ts
@@ -3,5 +3,6 @@ export const AppRoutes = {
   dogs: {
     report: "/dog-finder/dogs/report",
     search: "/dog-finder/dogs/search",
+    results: "/dog-finder/dogs/results",
   },
 };

--- a/src/consts/texts.ts
+++ b/src/consts/texts.ts
@@ -31,4 +31,8 @@ export const AppTexts = {
       reportPage: "דיווח על כלב",
     },
   },
+  resultsPage: {
+    title: "תוצאות חיפוש",
+    call: "לחץ להתקשרות",
+  }
 };

--- a/src/pages/dogs/ResultsDogPage.tsx
+++ b/src/pages/dogs/ResultsDogPage.tsx
@@ -1,0 +1,33 @@
+import { Box } from "@mui/material";
+import { PageContainer } from "../../components/pageComponents/PageContainer/PageContainer";
+import { PageTitle } from "../../components/pageComponents/PageTitle/PageTitle";
+import { AppTexts } from "../../consts/texts";
+import { ResultsGrid } from "../../components/resultsComponents/ResultsGrid";
+
+const results = [
+  { id: "1230", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
+  { id: "1231", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
+  { id: "1232", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
+  { id: "1233", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
+  { id: "1234", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
+  { id: "1235", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
+  { id: "1236", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
+  { id: "1237", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
+];
+
+export const ResultsDogPage = () => {
+  return (
+    <PageContainer>
+      <Box
+        height={"100%"}
+        display={"flex"}
+        flexDirection={"column"}
+        alignItems={"center"}
+        px={4}
+      >
+        <PageTitle text={AppTexts.resultsPage.title} />
+        <ResultsGrid results={results} />
+      </Box>
+    </PageContainer>
+  );
+};


### PR DESCRIPTION
This is a naive results page that displays a grid of images with a link to call their number.
<img width="402" alt="Screenshot 2023-10-14 at 15 11 44" src="https://github.com/galzo/dog-finder/assets/4344533/5bf148b5-30c3-454c-b84c-071c038aa345">
<img width="1075" alt="Screenshot 2023-10-14 at 15 11 59" src="https://github.com/galzo/dog-finder/assets/4344533/81acde28-7fb5-4afd-8fb9-e6b3c3f029e5">
<img width="1455" alt="Screenshot 2023-10-14 at 15 12 07" src="https://github.com/galzo/dog-finder/assets/4344533/8831d0d1-6473-47e2-bb57-e14a77e40ab0">
