### PR TITLE
Add different states to the results page - no styling.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0",
         "react-scripts": "5.0.1",
+        "swr": "^2.2.4",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
@@ -2346,6 +2347,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@emotion/babel-plugin/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
     "node_modules/@emotion/cache": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
@@ -2357,6 +2363,11 @@
         "@emotion/weak-memoize": "^0.3.1",
         "stylis": "4.2.0"
       }
+    },
+    "node_modules/@emotion/cache/node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.1",
@@ -6288,6 +6299,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -16568,11 +16584,6 @@
         "postcss": "^8.2.15"
       }
     },
-    "node_modules/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
-    },
     "node_modules/sucrase": {
       "version": "3.34.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.34.0.tgz",
@@ -16757,6 +16768,18 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dependencies": {
         "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.4.tgz",
+      "integrity": "sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -17365,6 +17388,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
+    "swr": "^2.2.4",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/src/components/resultsComponents/DogCard.tsx
+++ b/src/components/resultsComponents/DogCard.tsx
@@ -4,7 +4,7 @@ import { Dog } from "./ResultsGrid";
 
 export const DogCard = ({ dog }: { dog: Dog }) => {
   return (
-    <Card>
+    <Card dir="rtl">
       <CardMedia
         image={dog.image}
         component="img"

--- a/src/components/resultsComponents/ErrorLoadingDogs.tsx
+++ b/src/components/resultsComponents/ErrorLoadingDogs.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Alert, Button, Typography } from "@mui/material";
+import { AppTexts } from "../../consts/texts";
+import { KeyedMutator } from "swr";
+import { Dog } from "./ResultsGrid";
+
+export const ErrorLoadingDogs = ({
+  refresh,
+}: {
+  refresh: KeyedMutator<Dog[]>;
+}) => {
+  return (
+    <Alert
+      dir="rtl"
+      variant="filled"
+      severity="error"
+      action={
+        <Button color="inherit" size="small" onClick={() => refresh(undefined)}>
+          {AppTexts.resultsPage.refresh}
+        </Button>
+      }
+    >
+      <Typography px={6}>{AppTexts.resultsPage.error}</Typography>
+    </Alert>
+  );
+};

--- a/src/components/resultsComponents/LoadingDogs.tsx
+++ b/src/components/resultsComponents/LoadingDogs.tsx
@@ -1,0 +1,12 @@
+import { AppTexts } from "../../consts/texts";
+import { Typography, useTheme } from "@mui/material";
+
+export const LoadingDogs = () => {
+  const theme = useTheme();
+
+  return (
+    <Typography variant="h4" color={theme.palette.text.primary}>
+      {AppTexts.resultsPage.loading}
+    </Typography>
+  );
+};

--- a/src/components/resultsComponents/NoDogs.tsx
+++ b/src/components/resultsComponents/NoDogs.tsx
@@ -1,0 +1,12 @@
+import { AppTexts } from "../../consts/texts";
+import { Typography, useTheme } from "@mui/material";
+
+export const NoDogs = () => {
+  const theme = useTheme();
+
+  return (
+    <Typography variant="h4" color={theme.palette.text.primary}>
+      {AppTexts.resultsPage.noResults}
+    </Typography>
+  );
+};

--- a/src/components/resultsComponents/ResultsGrid.tsx
+++ b/src/components/resultsComponents/ResultsGrid.tsx
@@ -7,10 +7,10 @@ export type Dog = {
   image: string;
 };
 
-export const ResultsGrid = ({ results }: { results: Dog[] }) => {
+export const ResultsGrid = ({ results }: { results: Dog[] | undefined }) => {
   return (
     <Grid container spacing={2}>
-      {results.map((dog) => {
+      {results?.map((dog) => {
         return (
           <Grid item xs={12} md={6} lg={4} key={dog.id}>
             <DogCard dog={dog} />

--- a/src/consts/texts.ts
+++ b/src/consts/texts.ts
@@ -30,5 +30,9 @@ export const AppTexts = {
   resultsPage: {
     title: "תוצאות חיפוש",
     call: "לחץ להתקשרות",
+    error: "תקלה בטעינת התוצאות",
+    noResults: "לא נמצאו תוצאות",
+    refresh: "רענן",
+    loading: "...טוען תוצאות",
   }
 };

--- a/src/pages/dogs/ResultsDogPage.tsx
+++ b/src/pages/dogs/ResultsDogPage.tsx
@@ -1,10 +1,16 @@
+import useSWR, { Fetcher } from "swr";
 import { Box } from "@mui/material";
 import { PageContainer } from "../../components/pageComponents/PageContainer/PageContainer";
 import { PageTitle } from "../../components/pageComponents/PageTitle/PageTitle";
 import { AppTexts } from "../../consts/texts";
 import { ResultsGrid } from "../../components/resultsComponents/ResultsGrid";
+import type { Dog } from "../../components/resultsComponents/ResultsGrid";
+import { ErrorLoadingDogs } from "../../components/resultsComponents/ErrorLoadingDogs";
+import { LoadingDogs } from "../../components/resultsComponents/LoadingDogs";
+import { NoDogs } from "../../components/resultsComponents/NoDogs";
 
-const results = [
+// placeholder for integration
+const results: Dog[] = [
   { id: "1230", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
   { id: "1231", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
   { id: "1232", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
@@ -15,7 +21,19 @@ const results = [
   { id: "1237", phone: "123-456-7890", image: "https://picsum.photos/400/300" },
 ];
 
+const API_PATH = "/api/dogs";
+const fetcher: Fetcher<Dog[], string> = () => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(results);
+    }, 2000);
+  });
+};
+// placeholder done.
+
 export const ResultsDogPage = () => {
+  const { data: results, error, isLoading, mutate } = useSWR(API_PATH, fetcher);
+  const isEmpty = results?.length === 0;
   return (
     <PageContainer>
       <Box
@@ -26,7 +44,10 @@ export const ResultsDogPage = () => {
         px={4}
       >
         <PageTitle text={AppTexts.resultsPage.title} />
-        <ResultsGrid results={results} />
+        {isLoading && <LoadingDogs />}
+        {!isLoading && isEmpty && !error && <NoDogs />}
+        {!isLoading && error && <ErrorLoadingDogs refresh={mutate} />}
+        {!isLoading && !error && !isEmpty && <ResultsGrid results={results} />}
       </Box>
     </PageContainer>
   );


### PR DESCRIPTION
@galzo adding some simple states to the results page - 
Loading, NoData, and Error.

Currently using a simple fetcher function for the mock. I saw there's some work happening for a ServerAPI facade, will need to replace the fetcher with that a little later when we start integration.