### PR TITLE
refactor routes in app.tsx to make it cleaner

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -5,39 +5,39 @@ import { routesWithElements } from "../consts/routes";
 import { createStyleHook } from "../hooks/styleHooks";
 
 const useAppStyles = createStyleHook(() => {
-    return {
-        root: {
-            height: "100%",
-            overflow: "hidden",
-            position: "fixed",
-            top: 0,
-            left: 0,
-            width: "100%",
-            backgroundColor: theme.palette.background.default,
-        },
-    };
+  return {
+    root: {
+      height: "100%",
+      overflow: "hidden",
+      position: "fixed",
+      top: 0,
+      left: 0,
+      width: "100%",
+      backgroundColor: theme.palette.background.default,
+    },
+  };
 });
 
 export const App = () => {
-    const styles = useAppStyles();
+  const styles = useAppStyles();
 
-    return (
-        <ThemeProvider theme={theme}>
-            <Box sx={styles.root}>
-                <BrowserRouter>
-                    <Routes>
-                        {routesWithElements.map((route) => (
-                            <Route
-                                key={route.path}
-                                path={route.path}
-                                element={<route.element {...route.props} />}
-                            />
-                        ))}
-                        {/* //! path without an element */}
-                        {/* <Route path={"/dog-finder/dogs/report"} /> */}
-                    </Routes>
-                </BrowserRouter>
-            </Box>
-        </ThemeProvider>
-    );
+  return (
+    <ThemeProvider theme={theme}>
+      <Box sx={styles.root}>
+        <BrowserRouter>
+          <Routes>
+            {routesWithElements.map((route) => (
+              <Route
+                key={route.path}
+                path={route.path}
+                element={<route.element {...route.props} />}
+              />
+            ))}
+            {/* //! path without an element */}
+            {/* <Route path={"/dog-finder/dogs/report"} /> */}
+          </Routes>
+        </BrowserRouter>
+      </Box>
+    </ThemeProvider>
+  );
 };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,49 +1,43 @@
-import React from "react";
-import logo from "./logo.svg";
 import { Box, ThemeProvider } from "@mui/material";
 import { theme } from "../theme/theme";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import { HomePage } from "../pages/root/HomePage";
-import { AppRoutes } from "../consts/routes";
-import { ReportDogPage } from "../pages/dogs/ReportDogPage";
-import { SearchDogPage } from "../pages/dogs/SearchDogPage";
+import { routesWithElements } from "../consts/routes";
 import { createStyleHook } from "../hooks/styleHooks";
-import { ResultsDogPage } from "../pages/dogs/ResultsDogPage";
-import { DogType } from "../facades/payload.types";
 
 const useAppStyles = createStyleHook(() => {
-  return {
-    root: {
-      height: "100%",
-      overflow: "hidden",
-      position: "fixed",
-      top: 0,
-      left: 0,
-      width: "100%",
-      backgroundColor: theme.palette.background.default,
-    },
-  };
+    return {
+        root: {
+            height: "100%",
+            overflow: "hidden",
+            position: "fixed",
+            top: 0,
+            left: 0,
+            width: "100%",
+            backgroundColor: theme.palette.background.default,
+        },
+    };
 });
 
 export const App = () => {
-  const styles = useAppStyles();
+    const styles = useAppStyles();
 
-
-  return (
-    <ThemeProvider theme={theme}>
-      <Box sx={styles.root}>
-        <BrowserRouter>
-          <Routes>
-            <Route path={AppRoutes.root} element={<HomePage />} />
-            <Route path={AppRoutes.dogs.report} />
-            <Route path={AppRoutes.dogs.reportLost} element={<ReportDogPage dogType={DogType.LOST}/>} />
-            <Route path={AppRoutes.dogs.reportFound} element={<ReportDogPage dogType={DogType.FOUND}/>} />
-            <Route path={AppRoutes.dogs.searchLostDog} element={<SearchDogPage dogType={DogType.LOST}/>} />
-            <Route path={AppRoutes.dogs.searchFoundDog} element={<SearchDogPage  dogType={DogType.FOUND}/>} />
-            <Route path={AppRoutes.dogs.results} element={<ResultsDogPage />} />
-          </Routes>
-        </BrowserRouter>
-      </Box>
-    </ThemeProvider>
-  );
+    return (
+        <ThemeProvider theme={theme}>
+            <Box sx={styles.root}>
+                <BrowserRouter>
+                    <Routes>
+                        {routesWithElements.map((route) => (
+                            <Route
+                                key={route.path}
+                                path={route.path}
+                                element={<route.element {...route.props} />}
+                            />
+                        ))}
+                        {/* //! path without an element */}
+                        {/* <Route path={"/dog-finder/dogs/report"} /> */}
+                    </Routes>
+                </BrowserRouter>
+            </Box>
+        </ThemeProvider>
+    );
 };

--- a/src/consts/routes.ts
+++ b/src/consts/routes.ts
@@ -6,52 +6,52 @@ import { SearchDogPage } from "../pages/dogs/SearchDogPage";
 import { ResultsDogPage } from "../pages/dogs/ResultsDogPage";
 
 export const AppRoutes = {
-    root: "/dog-finder",
-    dogs: {
-        report: "/dog-finder/dogs/report",
-        reportFound: "/dog-finder/dogs/report-found",
-        reportLost: "/dog-finder/dogs/report-missing",
-        searchLostDog: "/dog-finder/dogs/search-lost",
-        searchFoundDog: "/dog-finder/dogs/search-found",
-        results: "/dog-finder/dogs/results/:dogType",
-    },
+  root: "/dog-finder",
+  dogs: {
+    report: "/dog-finder/dogs/report",
+    reportFound: "/dog-finder/dogs/report-found",
+    reportLost: "/dog-finder/dogs/report-missing",
+    searchLostDog: "/dog-finder/dogs/search-lost",
+    searchFoundDog: "/dog-finder/dogs/search-found",
+    results: "/dog-finder/dogs/results/:dogType",
+  },
 };
 
 type RouteElement = () => JSX.Element;
 
 interface Route {
-    path: string;
-    element: RouteElement | FC<any>;
-    props?: Record<any, any>;
+  path: string;
+  element: RouteElement | FC<any>;
+  props?: Record<any, any>;
 }
 
 export const routesWithElements: Route[] = [
-    {
-        path: AppRoutes.root,
-        element: HomePage,
-    },
-    {
-        path: AppRoutes.dogs.reportLost,
-        element: ReportDogPage as RouteElement,
-        props: { dogType: DogType.LOST },
-    },
-    {
-        path: AppRoutes.dogs.reportFound,
-        element: ReportDogPage as RouteElement,
-        props: { dogType: DogType.FOUND },
-    },
-    {
-        path: AppRoutes.dogs.searchLostDog,
-        element: SearchDogPage as RouteElement,
-        props: { dogType: DogType.LOST },
-    },
-    {
-        path: AppRoutes.dogs.searchFoundDog,
-        element: SearchDogPage as RouteElement,
-        props: { dogType: DogType.FOUND },
-    },
-    {
-        path: AppRoutes.dogs.results,
-        element: ResultsDogPage,
-    },
+  {
+    path: AppRoutes.root,
+    element: HomePage,
+  },
+  {
+    path: AppRoutes.dogs.reportLost,
+    element: ReportDogPage as RouteElement,
+    props: { dogType: DogType.LOST },
+  },
+  {
+    path: AppRoutes.dogs.reportFound,
+    element: ReportDogPage as RouteElement,
+    props: { dogType: DogType.FOUND },
+  },
+  {
+    path: AppRoutes.dogs.searchLostDog,
+    element: SearchDogPage as RouteElement,
+    props: { dogType: DogType.LOST },
+  },
+  {
+    path: AppRoutes.dogs.searchFoundDog,
+    element: SearchDogPage as RouteElement,
+    props: { dogType: DogType.FOUND },
+  },
+  {
+    path: AppRoutes.dogs.results,
+    element: ResultsDogPage,
+  },
 ];

--- a/src/consts/routes.ts
+++ b/src/consts/routes.ts
@@ -1,11 +1,57 @@
+import { FC } from "react";
+import { DogType } from "../facades/payload.types";
+import { HomePage } from "./../pages/root/HomePage";
+import { ReportDogPage } from "../pages/dogs/ReportDogPage";
+import { SearchDogPage } from "../pages/dogs/SearchDogPage";
+import { ResultsDogPage } from "../pages/dogs/ResultsDogPage";
+
 export const AppRoutes = {
-  root: "/dog-finder",
-  dogs: {
-    report: "/dog-finder/dogs/report",
-    reportFound: "/dog-finder/dogs/report-found",
-    reportLost: "/dog-finder/dogs/report-missing",
-    searchLostDog: "/dog-finder/dogs/search-lost",
-    searchFoundDog: "/dog-finder/dogs/search-found",
-    results: "/dog-finder/dogs/results/:dogType",
-  },
+    root: "/dog-finder",
+    dogs: {
+        report: "/dog-finder/dogs/report",
+        reportFound: "/dog-finder/dogs/report-found",
+        reportLost: "/dog-finder/dogs/report-missing",
+        searchLostDog: "/dog-finder/dogs/search-lost",
+        searchFoundDog: "/dog-finder/dogs/search-found",
+        results: "/dog-finder/dogs/results/:dogType",
+    },
 };
+
+type RouteElement = () => JSX.Element;
+
+interface Route {
+    path: string;
+    element: RouteElement | FC<any>;
+    props?: Record<any, any>;
+}
+
+export const routesWithElements: Route[] = [
+    {
+        path: AppRoutes.root,
+        element: HomePage,
+    },
+    {
+        path: AppRoutes.dogs.reportLost,
+        element: ReportDogPage as RouteElement,
+        props: { dogType: DogType.LOST },
+    },
+    {
+        path: AppRoutes.dogs.reportFound,
+        element: ReportDogPage as RouteElement,
+        props: { dogType: DogType.FOUND },
+    },
+    {
+        path: AppRoutes.dogs.searchLostDog,
+        element: SearchDogPage as RouteElement,
+        props: { dogType: DogType.LOST },
+    },
+    {
+        path: AppRoutes.dogs.searchFoundDog,
+        element: SearchDogPage as RouteElement,
+        props: { dogType: DogType.FOUND },
+    },
+    {
+        path: AppRoutes.dogs.results,
+        element: ResultsDogPage,
+    },
+];


### PR DESCRIPTION
This is not related to a ticket, but I wanted to clean-up App.tsx by moving out the routes data to an array of objects, where each object has a path, element and props.
This will replace the hard-coded routes we're currently using in App.tsx